### PR TITLE
Students can only submit 1 question per queue

### DIFF
--- a/backend/ohq/permissions.py
+++ b/backend/ohq/permissions.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 from rest_framework import permissions
 
 from ohq.models import Course, Membership, Question
@@ -158,7 +159,9 @@ class QuestionPermission(permissions.BasePermission):
         # Students can only create 1 question per queue
         if view.action == "create":
             existing_question = Question.objects.filter(
-                queue=view.kwargs["queue_pk"], asked_by=request.user
+                Q(queue=view.kwargs["queue_pk"])
+                & Q(asked_by=request.user)
+                & (Q(status=Question.STATUS_ASKED) | Q(status=Question.STATUS_ACTIVE))
             ).first()
 
             return membership.kind == Membership.KIND_STUDENT and existing_question is None

--- a/backend/tests/ohq/test_permissions.py
+++ b/backend/tests/ohq/test_permissions.py
@@ -387,7 +387,8 @@ class QuestionTestCase(TestCase):
 
     @parameterized.expand(users, name_func=get_test_name)
     def test_create(self, user):
-        self.question.delete()
+        self.question.status = Question.STATUS_ANSWERED
+        self.question.save()
         test(
             self,
             user,

--- a/backend/tests/ohq/test_permissions.py
+++ b/backend/tests/ohq/test_permissions.py
@@ -328,6 +328,7 @@ class QuestionTestCase(TestCase):
                 "non_member": 403,
                 "anonymous": 403,
             },
+            "create-existing": {"student": 403},
             "retrieve": {
                 "professor": 200,
                 "head_ta": 200,
@@ -386,6 +387,7 @@ class QuestionTestCase(TestCase):
 
     @parameterized.expand(users, name_func=get_test_name)
     def test_create(self, user):
+        self.question.delete()
         test(
             self,
             user,
@@ -393,6 +395,20 @@ class QuestionTestCase(TestCase):
             "post",
             reverse("ohq:question-list", args=[self.course.id, self.queue.id]),
             {"text": "question", "description": "description"},
+        )
+
+    def test_create_student_existing(self):
+        """
+        Ensure a student can't submit multiple questions to a queue.
+        """
+
+        test(
+            self,
+            "student",
+            "create-existing",
+            "post",
+            reverse("ohq:question-list", args=[self.course.id, self.queue.id]),
+            {"text": "question"},
         )
 
     @parameterized.expand(users, name_func=get_test_name)

--- a/backend/tests/ohq/test_serializers.py
+++ b/backend/tests/ohq/test_serializers.py
@@ -185,9 +185,13 @@ class QuestionSerializerTestCase(TestCase):
         self.queue = Queue.objects.create(name="Queue", course=self.course)
         self.ta = User.objects.create(username="ta")
         self.student = User.objects.create(username="student")
+        self.student2 = User.objects.create(username="student2")
         Membership.objects.create(course=self.course, user=self.ta, kind=Membership.KIND_TA)
         Membership.objects.create(
             course=self.course, user=self.student, kind=Membership.KIND_STUDENT
+        )
+        Membership.objects.create(
+            course=self.course, user=self.student2, kind=Membership.KIND_STUDENT
         )
         self.question_text = "This is a question"
         self.question = Question.objects.create(
@@ -195,13 +199,13 @@ class QuestionSerializerTestCase(TestCase):
         )
 
     def test_create(self, mock_delay):
-        self.client.force_authenticate(user=self.student)
+        self.client.force_authenticate(user=self.student2)
         self.client.post(
             reverse("ohq:question-list", args=[self.course.id, self.queue.id]), {"text": "Help me"}
         )
         self.assertEqual(2, Question.objects.all().count())
         question = Question.objects.all().order_by("time_asked")[1]
-        self.assertEqual(self.student, question.asked_by)
+        self.assertEqual(self.student2, question.asked_by)
         self.assertEqual(Question.STATUS_ASKED, question.status)
         mock_delay.assert_not_called()
 


### PR DESCRIPTION
This PR limits prevents students from asking more than one question in a queue and updates related tests.