### PR TITLE
Revert "Fix next links"

### DIFF
--- a/frontend/components/Home/Dashboard/Cards/CourseCard.tsx
+++ b/frontend/components/Home/Dashboard/Cards/CourseCard.tsx
@@ -14,6 +14,10 @@ const CourseCard = (props: CourseCardProps) => {
     const { course } = membership;
     const [hover, setHover] = useState(false);
 
+    const path = {
+        pathname: `/courses/${course.id}`,
+    };
+
     const handleLeave = () => {
         if (setLeaveMembership && setOpenLeave) {
             setLeaveMembership(membership);
@@ -23,7 +27,7 @@ const CourseCard = (props: CourseCardProps) => {
 
     return (
         <Segment basic>
-            <Link href="/courses/[course]" as={`/courses/${course.id}`}>
+            <Link href={path}>
                 <Segment.Group
                     style={{
                         cursor: "pointer",


### PR DESCRIPTION
Reverts pennlabs/office-hours-queue#67

Turns out, a subtle bug in frontend-core might cause this fix to overload our WS servers :|
Client-side transitions means that WS connections aren't actually forcefully disconnected, and RLH does not disconnect the connection on unmount. 


Not sure how serious it is so I'm reverting for good measure