### PR TITLE
Switch rate limiting to use time responded to

### DIFF
--- a/backend/ohq/views.py
+++ b/backend/ohq/views.py
@@ -249,7 +249,7 @@ class QuestionViewSet(viewsets.ModelViewSet):
         return Question.objects.filter(
             queue=queue,
             asked_by=user,
-            time_asked__gte=timezone.now() - timedelta(minutes=queue.rate_limit_minutes),
+            time_responded_to__gte=timezone.now() - timedelta(minutes=queue.rate_limit_minutes),
         ).exclude(status__in=[Question.STATUS_REJECTED, Question.STATUS_WITHDRAWN])
 
     def create(self, request, *args, **kwargs):
@@ -287,10 +287,10 @@ class QuestionViewSet(viewsets.ModelViewSet):
                 >= queue.rate_limit_length
                 and count >= queue.rate_limit_questions
             ):
-                last_question = questions.order_by("-time_asked")[queue.rate_limit_questions - 1]
+                last_question = questions.order_by("-time_responded_to")[queue.rate_limit_questions - 1]
                 wait_time_secs = (
                     queue.rate_limit_minutes * 60
-                    - (timezone.now() - last_question.time_asked).total_seconds()
+                    - (timezone.now() - last_question.time_responded_to).total_seconds()
                 )
                 wait_time_mins = math.ceil(wait_time_secs / 60)
 

--- a/backend/ohq/views.py
+++ b/backend/ohq/views.py
@@ -287,7 +287,9 @@ class QuestionViewSet(viewsets.ModelViewSet):
                 >= queue.rate_limit_length
                 and count >= queue.rate_limit_questions
             ):
-                last_question = questions.order_by("-time_responded_to")[queue.rate_limit_questions - 1]
+                last_question = questions.order_by("-time_responded_to")[
+                    queue.rate_limit_questions - 1
+                ]
                 wait_time_secs = (
                     queue.rate_limit_minutes * 60
                     - (timezone.now() - last_question.time_responded_to).total_seconds()

--- a/backend/tests/ohq/test_views.py
+++ b/backend/tests/ohq/test_views.py
@@ -149,12 +149,15 @@ class QuestionViewTestCase(TestCase):
         self.question = Question.objects.create(
             queue=self.queue, asked_by=self.student, text="Help me"
         )
+        self.question.time_asked = timezone.now() - timedelta(days=1)
+        self.question.save()
+
         self.old_question = Question.objects.create(
             queue=self.queue,
             asked_by=self.student,
             text="Help me",
-            time_responded_to=timezone.now(),
-            time_response_started=timezone.now(),
+            time_responded_to=timezone.now() - timedelta(days=1),
+            time_response_started=timezone.now() - timedelta(days=1),
             responded_to_by=self.ta,
             status=Question.STATUS_ANSWERED,
         )
@@ -180,10 +183,10 @@ class QuestionViewTestCase(TestCase):
             queue=self.queue2, asked_by=self.student3, text="Help me"
         )
 
-        self.prelimit_question1.time_asked = timezone.now() - timedelta(minutes=3)
-        self.prelimit_question2.time_asked = timezone.now() - timedelta(minutes=6)
+        self.prelimit_question.time_responded_to = timezone.now() - timedelta(minutes=3)
+        self.prelimit_question1.time_responded_to = timezone.now() - timedelta(minutes=6)
+        self.prelimit_question.save()
         self.prelimit_question1.save()
-        self.prelimit_question2.save()
 
         Question.objects.create(queue=self.queue3, asked_by=self.student3, text="Help me")
 
@@ -223,7 +226,7 @@ class QuestionViewTestCase(TestCase):
         res = self.client.get(
             reverse("ohq:question-quota-count", args=[self.course.id, self.queue2.id])
         )
-        self.assertEqual(12, json.loads(res.content)["wait_time_mins"])
+        self.assertEqual(9, json.loads(res.content)["wait_time_mins"])
 
         res = self.client.get(
             reverse("ohq:question-quota-count", args=[self.course.id, self.queue3.id])


### PR DESCRIPTION
Backend change that updates rate limiting to look at time responded to instead of time asked.