### PR TITLE
Fix course retrieve permission

### DIFF
--- a/backend/ohq/permissions.py
+++ b/backend/ohq/permissions.py
@@ -35,7 +35,7 @@ class CoursePermission(permissions.BasePermission):
         # Anyone can get a single course
         if view.action == "retrieve":
             return True
-        
+
         membership = Membership.objects.filter(course=obj, user=request.user).first()
 
         # Non members can't do anything other than retrieve a course

--- a/backend/ohq/permissions.py
+++ b/backend/ohq/permissions.py
@@ -32,15 +32,15 @@ class CoursePermission(permissions.BasePermission):
     """
 
     def has_object_permission(self, request, view, obj):
-        membership = Membership.objects.filter(course=obj, user=request.user).first()
-
-        # Non members can't do anything
-        if membership is None:
-            return False
-
         # Anyone can get a single course
         if view.action == "retrieve":
             return True
+        
+        membership = Membership.objects.filter(course=obj, user=request.user).first()
+
+        # Non members can't do anything other than retrieve a course
+        if membership is None:
+            return False
 
         # No one can delete a course
         if view.action == "destroy":

--- a/backend/tests/ohq/test_permissions.py
+++ b/backend/tests/ohq/test_permissions.py
@@ -99,7 +99,7 @@ class CourseTestCase(TestCase):
                 "head_ta": 200,
                 "ta": 200,
                 "student": 200,
-                "non_member": 403,
+                "non_member": 200,
                 "anonymous": 403,
             },
             "destroy": {


### PR DESCRIPTION
This PR changes the backend permission so a user can retrieve any course (including courses they aren't a member of). Note that the queryset in the CourseViewSet will make sure that invite only courses that a user isn't a member of can't be accessed.