### PR TITLE
[WIP] Show Active Staff Information

### DIFF
--- a/backend/ohq/permissions.py
+++ b/backend/ohq/permissions.py
@@ -243,6 +243,7 @@ class MembershipPermission(permissions.BasePermission):
 
         # Students+ can get, modify, and delete memberships
         # can list memberships of leaders.
+        # can also list any active TA's
         # With restrictions defined in has_object_permission
         return True
 

--- a/backend/ohq/serializers.py
+++ b/backend/ohq/serializers.py
@@ -133,7 +133,6 @@ class MembershipInviteSerializer(CourseRouteMixin):
 class QueueSerializer(CourseRouteMixin):
     questions_active = serializers.IntegerField(default=0, read_only=True)
     questions_asked = serializers.IntegerField(default=0, read_only=True)
-    staff_active = serializers.IntegerField(default=0, read_only=True)
 
     class Meta:
         model = Queue
@@ -146,7 +145,6 @@ class QueueSerializer(CourseRouteMixin):
             "active",
             "questions_active",
             "questions_asked",
-            "staff_active",
             "rate_limit_enabled",
             "rate_limit_length",
             "rate_limit_questions",

--- a/backend/ohq/views.py
+++ b/backend/ohq/views.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from django.contrib.auth import get_user_model
 from django.core.validators import ValidationError
-from django.db.models import Count, Exists, FloatField, IntegerField, OuterRef, Q, Subquery
+from django.db.models import Count, Exists, IntegerField, OuterRef, Q, Subquery
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.utils import timezone
 from django.utils.crypto import get_random_string
@@ -471,12 +471,12 @@ class MembershipViewSet(viewsets.ModelViewSet):
             )
         return prefetch(qs, self.serializer_class)
 
-    @action(detail=False, url_path="staffActive")
+    @action(detail=False)
     def staff_active(self, request, course_pk):
         """
         Get's the active staff in a course
         """
-    
+
         time_threshold = timezone.now() - timedelta(minutes=1)
 
         staff_active = Membership.objects.filter(

--- a/backend/tests/ohq/test_permissions.py
+++ b/backend/tests/ohq/test_permissions.py
@@ -769,6 +769,14 @@ class MembershipTestCase(TestCase):
                 "non_member": 403,
                 "anonymous": 403,
             },
+            "staff-active": {
+                "professor": 200,
+                "head_ta": 200,
+                "ta": 200,
+                "student": 200,
+                "non_member": 403,
+                "anonymous": 403,
+            },
         }
 
     @parameterized.expand(users, name_func=get_test_name)
@@ -828,6 +836,16 @@ class MembershipTestCase(TestCase):
             "patch",
             reverse("ohq:member-detail", args=[self.course.id, self.membership.id]),
             {"description": "new"},
+        )
+
+    @parameterized.expand(users, name_func=get_test_name)
+    def test_staff_active(self, user):
+        test(
+            self,
+            user,
+            "staff-active",
+            "get",
+            reverse("ohq:member-staff-active", args=[self.course.id]),
         )
 
 

--- a/backend/tests/ohq/test_views.py
+++ b/backend/tests/ohq/test_views.py
@@ -9,7 +9,7 @@ from djangorestframework_camel_case.util import camelize
 from rest_framework.test import APIClient
 
 from ohq.models import Course, Membership, MembershipInvite, Question, Queue, Semester
-from ohq.serializers import UserPrivateSerializer
+from ohq.serializers import MembershipSerializer, UserPrivateSerializer
 
 
 User = get_user_model()
@@ -232,3 +232,78 @@ class QuestionViewTestCase(TestCase):
             reverse("ohq:question-quota-count", args=[self.course.id, self.queue3.id])
         )
         self.assertEqual(0, json.loads(res.content)["wait_time_mins"])
+
+
+class MembershipViewTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.semester = Semester.objects.create(year=2020, term=Semester.TERM_FALL)
+        self.course = Course.objects.create(
+            course_code="000", department="Test Class", semester=self.semester
+        )
+        self.queue = Queue.objects.create(name="Queue", course=self.course)
+
+        self.head_ta = User.objects.create_user("head_ta", "head_ta@a.com", "head_ta")
+        self.ta = User.objects.create_user("ta", "ta@a.com", "ta")
+        self.student = User.objects.create_user("student", "student@a.com", "student")
+
+        self.head_ta_membership = Membership.objects.create(
+            course=self.course, user=self.head_ta, kind=Membership.KIND_HEAD_TA
+        )
+        self.ta_membership = Membership.objects.create(
+            course=self.course, user=self.ta, kind=Membership.KIND_TA
+        )
+        self.student_membership = Membership.objects.create(
+            course=self.course, user=self.student, kind=Membership.KIND_STUDENT
+        )
+
+    def test_staff_active(self):
+        self.client.force_authenticate(user=self.student)
+
+        res = self.client.get(reverse("ohq:member-staff-active", args=[self.course.id]))
+        content = json.loads(res.content)
+
+        self.assertEqual(0, len(content))
+
+        self.head_ta_membership.last_active = timezone.now()
+        self.head_ta_membership.save()
+
+        res = self.client.get(reverse("ohq:member-staff-active", args=[self.course.id]))
+        content = json.loads(res.content)
+
+        self.assertEqual(1, len(content))
+        expected_content = camelize(MembershipSerializer([self.head_ta_membership], many=True).data)
+        self.assertEqual(expected_content, content)
+
+        self.ta_membership.last_active = timezone.now()
+        self.ta_membership.save()
+
+        res = self.client.get(reverse("ohq:member-staff-active", args=[self.course.id]))
+        content = json.loads(res.content)
+
+        self.assertEqual(2, len(content))
+        expected_content = camelize(
+            MembershipSerializer([self.head_ta_membership, self.ta_membership], many=True).data
+        )
+        self.assertEqual(expected_content, content)
+
+        self.head_ta_membership.last_active = timezone.now() - timezone.timedelta(minutes=5)
+        self.head_ta_membership.save()
+
+        res = self.client.get(reverse("ohq:member-staff-active", args=[self.course.id]))
+        content = json.loads(res.content)
+
+        expected_content = camelize(MembershipSerializer([self.ta_membership], many=True).data)
+        self.assertEqual(expected_content, content)
+
+        self.assertEqual(1, len(content))
+
+        self.student_membership.last_active = timezone.now()
+        self.student_membership.save()
+
+        res = self.client.get(reverse("ohq:member-staff-active", args=[self.course.id]))
+        content = json.loads(res.content)
+
+        self.assertEqual(1, len(content))
+        expected_content = camelize(MembershipSerializer([self.ta_membership], many=True).data)
+        self.assertEqual(expected_content, content)


### PR DESCRIPTION
This PR allows queues to provide information about active staff through an added action under MembershipViewSet to get all staff that are active for a course.