### PR TITLE
Archive courses for fall 2021- update dashboard welcome message on front end

### DIFF
--- a/frontend/components/Home/Dashboard/Dashboard.tsx
+++ b/frontend/components/Home/Dashboard/Dashboard.tsx
@@ -9,7 +9,7 @@ import { AuthUserContext } from "../../../context/auth";
 import { Kind, UserMembership } from "../../../types";
 import { useMemberships } from "../../../hooks/data-fetching/dashboard";
 import { isLeadershipRole } from "../../../utils/enums";
-import { ANALYTICS_SURVEY_SHOWN_SPRING_2021_END_TOKEN } from "../../../constants";
+import { FALL_2021_TRANSITION_MESSAGE_TOKEN } from "../../../constants";
 
 // TODO: try to readd new user stuff, rip out loading stuff
 const Dashboard = () => {
@@ -19,9 +19,7 @@ const Dashboard = () => {
     }
     const [messageDisp, setMessageDisp] = useState(false);
     useEffect(() => {
-        const state = localStorage.getItem(
-            ANALYTICS_SURVEY_SHOWN_SPRING_2021_END_TOKEN
-        );
+        const state = localStorage.getItem(FALL_2021_TRANSITION_MESSAGE_TOKEN);
         setMessageDisp(state !== "true");
     }, []);
 
@@ -75,26 +73,20 @@ const Dashboard = () => {
                                     onDismiss={() => {
                                         setMessageDisp(false);
                                         localStorage.setItem(
-                                            ANALYTICS_SURVEY_SHOWN_SPRING_2021_END_TOKEN,
+                                            FALL_2021_TRANSITION_MESSAGE_TOKEN,
                                             "true"
                                         );
                                     }}
                                     size="mini"
-                                    header="The semester is ending..."
+                                    header="Welcome back!"
                                     content={
                                         <>
-                                            and we want to hear from you! Help
-                                            us improve OHQ by filling
+                                            Spring and Summer 2021 courses have
+                                            been archived in preparation for
+                                            Fall 2021.
                                             <br />
-                                            out our{" "}
-                                            <a
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                                href="https://airtable.com/shrFrWqkc6vVNziIa"
-                                            >
-                                                end-of-semester survey
-                                            </a>{" "}
-                                            today!
+                                            Please contact us at contact@ohq.io
+                                            if this is an error.
                                         </>
                                     }
                                 />

--- a/frontend/constants.ts
+++ b/frontend/constants.ts
@@ -18,3 +18,5 @@ export const SPRING_2021_TRANSITION_MESSAGE_TOKEN =
     "__spring_2021_transition_message_shown";
 export const ANALYTICS_SURVEY_SHOWN_SPRING_2021_END_TOKEN =
     "__analytics_survey_sp_2021_end_shown";
+export const FALL_2021_TRANSITION_MESSAGE_TOKEN =
+    "__fall_2021_transition_message_shown";


### PR DESCRIPTION
New message:
![image](https://user-images.githubusercontent.com/52753462/131435762-54395bc3-19d4-46db-a1e4-e3f71dfc8075.png)

Tested that "__fall_2021_transition_message_shown" is set to true after page renders the first time in local storage
Tested that message disappears after refresh OR clicking x icon