### PR TITLE
Fix/mobile create announcement react responsive

### DIFF
--- a/frontend/components/Course/Announcements.tsx
+++ b/frontend/components/Course/Announcements.tsx
@@ -326,24 +326,16 @@ export default function Announcements(props: AnnouncementsProps) {
                         {numUnread} Unread)
                     </Accordion.Title>
                     {staff && (
-                        // <Button
-                        //     style={{
-                        //         position: "absolute",
-                        //         right: "0.8rem",
-                        //         top: "0.5rem",
-                        //     }}
-                        //     onClick={() => setNewState(true)}
-                        //     primary
-                        // >
-                        //     <Icon name="plus" />
-                        //     Create New
-                        // </Button>
                         <ResponsiveIconButton
                             onClick={() => setNewState(true)}
                             primary
                             icon={<Icon name="plus" />}
-                            labelPosition="left"
-                            mobileProps={{ compact: true }}
+                            desktopProps={{ labelPosition: "left" }}
+                            style={{
+                                position: "absolute",
+                                right: "0.8rem",
+                                top: "0.5rem",
+                            }}
                             text="Create New"
                         />
                     )}

--- a/frontend/components/Course/Announcements.tsx
+++ b/frontend/components/Course/Announcements.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import {
     Accordion,
     Dropdown,
@@ -15,6 +15,7 @@ import {
     useAnnouncements,
     createAnnouncement,
 } from "../../hooks/data-fetching/course";
+import ResponsiveIconButton from "../common/ui/ResponsiveIconButton";
 
 interface AnnouncementsProps {
     courseId: number;
@@ -325,18 +326,26 @@ export default function Announcements(props: AnnouncementsProps) {
                         {numUnread} Unread)
                     </Accordion.Title>
                     {staff && (
-                        <Button
-                            style={{
-                                position: "absolute",
-                                right: "0.8rem",
-                                top: "0.5rem",
-                            }}
+                        // <Button
+                        //     style={{
+                        //         position: "absolute",
+                        //         right: "0.8rem",
+                        //         top: "0.5rem",
+                        //     }}
+                        //     onClick={() => setNewState(true)}
+                        //     primary
+                        // >
+                        //     <Icon name="plus" />
+                        //     Create New
+                        // </Button>
+                        <ResponsiveIconButton
                             onClick={() => setNewState(true)}
                             primary
-                        >
-                            <Icon name="plus" />
-                            Create New
-                        </Button>
+                            icon={<Icon name="plus" />}
+                            labelPosition="left"
+                            mobileProps={{ compact: true }}
+                            text="Create New"
+                        />
                     )}
                     <Accordion.Content active={open}>
                         {announcements!.map((a) => (

--- a/frontend/components/common/ui/ResponsiveIconButton.tsx
+++ b/frontend/components/common/ui/ResponsiveIconButton.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import { useMediaQuery } from "@material-ui/core";
-import { Button, StrictButtonProps } from "semantic-ui-react";
+import { Button, ButtonProps } from "semantic-ui-react";
 import { MOBILE_BP } from "../../../constants";
 
-interface ResponsiveIconButtonProps extends StrictButtonProps {
+interface ResponsiveIconButtonProps extends ButtonProps {
     text: string;
-    icon: NonNullable<StrictButtonProps["icon"]>;
-    mobileProps?: StrictButtonProps;
+    icon: NonNullable<ButtonProps["icon"]>;
+    mobileProps?: ButtonProps;
+    desktopProps?: ButtonProps;
 }
 
 /* Icon button with text component. Text disappears at smaller breakpoints to leave only the icon */
@@ -14,13 +15,14 @@ const ResponsiveIconButton = ({
     text,
     icon,
     mobileProps,
+    desktopProps,
     ...sharedProps
 }: ResponsiveIconButtonProps) => {
     const isMobile = useMediaQuery(`(max-width: ${MOBILE_BP})`);
 
     const iconButton = <Button icon={icon} {...sharedProps} {...mobileProps} />;
     const iconTextButton = (
-        <Button icon {...sharedProps}>
+        <Button icon {...sharedProps} {...desktopProps}>
             {icon}
             {text}
         </Button>

--- a/frontend/components/common/ui/ResponsiveIconButton.tsx
+++ b/frontend/components/common/ui/ResponsiveIconButton.tsx
@@ -1,0 +1,32 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import { useMediaQuery } from "@material-ui/core";
+import { Button, StrictButtonProps } from "semantic-ui-react";
+import { MOBILE_BP } from "../../../constants";
+
+interface ResponsiveIconButtonProps extends StrictButtonProps {
+    text: string;
+    icon: NonNullable<StrictButtonProps["icon"]>;
+    mobileProps?: StrictButtonProps;
+}
+
+/* Icon button with text component. Text disappears at smaller breakpoints to leave only the icon */
+const ResponsiveIconButton = ({
+    text,
+    icon,
+    mobileProps,
+    ...sharedProps
+}: ResponsiveIconButtonProps) => {
+    const isMobile = useMediaQuery(`(max-width: ${MOBILE_BP})`);
+
+    const iconButton = <Button icon={icon} {...sharedProps} {...mobileProps} />;
+    const iconTextButton = (
+        <Button icon {...sharedProps}>
+            {icon}
+            {text}
+        </Button>
+    );
+
+    return isMobile ? iconButton : iconTextButton;
+};
+
+export default ResponsiveIconButton;

--- a/frontend/constants.ts
+++ b/frontend/constants.ts
@@ -20,3 +20,5 @@ export const ANALYTICS_SURVEY_SHOWN_SPRING_2021_END_TOKEN =
     "__analytics_survey_sp_2021_end_shown";
 export const FALL_2021_TRANSITION_MESSAGE_TOKEN =
     "__fall_2021_transition_message_shown";
+
+export const MOBILE_BP = "600px";


### PR DESCRIPTION
ch3407

Fix create new announcement button from overlapping with announcement text on mobile
This fix ran into issues with Semantic UI spacing when I tried to use CSS media queries. Instead I'm using a useMediaQuery hook to conditionally pass props into the semantic UI component

The responsive button component should also be reusable

Desktop (chrome)
![image](https://user-images.githubusercontent.com/52753462/136597098-d2530539-4e29-40a7-9c83-6ae2f5dc8ef4.png)

Mobile (chrome)
![image](https://user-images.githubusercontent.com/52753462/136597154-6f36ca2a-1b2a-4094-979c-c2aa1cd6ff07.png)

Will check on my actual phone after merging