### PR TITLE
Fix newlines in question cards

### DIFF
--- a/frontend/components/Course/InstructorQueuePage/QuestionCard.tsx
+++ b/frontend/components/Course/InstructorQueuePage/QuestionCard.tsx
@@ -169,7 +169,7 @@ const QuestionCard = (props: QuestionCardProps) => {
             <Segment
                 attached
                 tertiary={question.timeResponseStarted !== null}
-                style={{ overflowWrap: "anywhere" }}
+                style={{ whiteSpace: "break-spaces", wordBreak: "break-word" }}
             >
                 {question.text}
             </Segment>

--- a/frontend/components/Course/StudentQueuePage/QuestionCard.tsx
+++ b/frontend/components/Course/StudentQueuePage/QuestionCard.tsx
@@ -113,7 +113,7 @@ const QuestionCard = (props: QuestionCardProps) => {
             <Segment
                 attached
                 tertiary={question.timeResponseStarted !== null}
-                style={{ overflowWrap: "anywhere" }}
+                style={{ whiteSpace: "break-spaces", wordBreak: "break-word" }}
             >
                 {question.text}
                 {question.note && !question.resolvedNote && (


### PR DESCRIPTION
For the instructor and student view, whitespace has not been preserved (bug found after question templates PR #150). This PR addresses this.

<img width="1023" alt="image" src="https://user-images.githubusercontent.com/2627736/136981078-86a22855-849f-4019-bd82-a39b7bea9b70.png">
