### PR TITLE
remove announcement icon on mobile

### DIFF
--- a/frontend/components/Course/Announcements.tsx
+++ b/frontend/components/Course/Announcements.tsx
@@ -9,6 +9,7 @@ import {
     Button,
 } from "semantic-ui-react";
 import { mutateResourceListFunction } from "@pennlabs/rest-hooks/dist/types";
+import { useMediaQuery } from "@material-ui/core";
 import { Announcement, BaseUser, NotificationProps } from "../../types";
 import { AuthUserContext } from "../../context/auth";
 import {
@@ -16,6 +17,7 @@ import {
     createAnnouncement,
 } from "../../hooks/data-fetching/course";
 import ResponsiveIconButton from "../common/ui/ResponsiveIconButton";
+import { MOBILE_BP } from "../../constants";
 
 interface AnnouncementsProps {
     courseId: number;
@@ -172,6 +174,7 @@ const AnnouncementMessage = ({
     setDeleteState: (state: ModalState) => void;
     setEditState: (state: ModalState) => void;
 }) => {
+    const isMobile = useMediaQuery(`(max-width: ${MOBILE_BP})`);
     return (
         <>
             <Message icon>
@@ -220,7 +223,7 @@ const AnnouncementMessage = ({
                         </Dropdown.Menu>
                     </Dropdown>
                 )}
-                <Icon name="comment alternate outline" />
+                {!isMobile && <Icon name="comment alternate outline" />}
                 <Message.Content style={{ paddingBottom: "1rem" }}>
                     <Message.Header>{`From ${announcement.author.firstName}`}</Message.Header>
                     <p


### PR DESCRIPTION
Old. Icon takes up too much space on mobile.
![image](https://user-images.githubusercontent.com/70118730/140657966-adb6a5a4-ea4b-4496-8d12-9ebc96a12ef0.png)

New. Remove icon to leave more space for announcement
![image](https://user-images.githubusercontent.com/70118730/140657982-d1b1548f-1c5e-4b11-a35e-504742f58ced.png)
