### PR TITLE
prevent multiline sidebar

### DIFF
--- a/frontend/components/Course/CourseSidebarNav.tsx
+++ b/frontend/components/Course/CourseSidebarNav.tsx
@@ -76,6 +76,13 @@ const CourseSidebarNav = (props: CourseSidebarProps) => {
                             active={router.pathname.endsWith("analytics")}
                             color="blue"
                         >
+                            <Icon
+                                name="chart bar"
+                                style={{
+                                    float: "right",
+                                    margin: "0 0 0 .5em",
+                                }}
+                            />
                             Analytics
                             <Label
                                 color="violet"
@@ -84,13 +91,6 @@ const CourseSidebarNav = (props: CourseSidebarProps) => {
                                 style={{
                                     float: "none",
                                     verticalAlign: "bottom",
-                                }}
-                            />
-                            <Icon
-                                name="chart bar"
-                                style={{
-                                    float: "right",
-                                    margin: "0 0 0 .5em",
                                 }}
                             />
                         </Menu.Item>


### PR DESCRIPTION
Now the component is always on one line.
![image](https://user-images.githubusercontent.com/70118730/151711999-e8bf57f5-5cc1-416e-91bf-0352519b1cc5.png)
Before there was a weird multiline issue.
![image](https://user-images.githubusercontent.com/70118730/151712033-cd3a75f4-9fa1-467c-a3e8-2d830258e244.png)
