### PR TITLE
Switch over to DOMAINS env variable

### DIFF
--- a/backend/officehoursqueue/settings/base.py
+++ b/backend/officehoursqueue/settings/base.py
@@ -15,7 +15,7 @@ import os
 import dj_database_url
 
 
-DOMAIN = os.environ.get("DOMAIN", "example.com")
+DOMAIN = os.environ.get("DOMAINS", "example.com")
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))


### PR DESCRIPTION
For consistency purposes, Kittyhawk uses `DOMAINS` (instead of the `DOMAIN`) env variable. This PR makes the necessary changes to switch over