### PR TITLE
Paginate roster

### DIFF
--- a/frontend/components/Course/Roster/Roster.tsx
+++ b/frontend/components/Course/Roster/Roster.tsx
@@ -488,23 +488,14 @@ const Roster = (props: RosterProps) => {
                                                     event,
                                                     { activePage }
                                                 ) => {
-                                                    let parsedPage: number;
-                                                    if (
+                                                    const parsedPage: number =
                                                         typeof activePage ===
                                                         "string"
-                                                    ) {
-                                                        parsedPage = parseInt(
-                                                            activePage,
-                                                            10
-                                                        );
-                                                    } else if (
-                                                        typeof activePage ===
-                                                        "number"
-                                                    ) {
-                                                        parsedPage = activePage;
-                                                    } else {
-                                                        parsedPage = 1;
-                                                    }
+                                                            ? parseInt(
+                                                                  activePage,
+                                                                  10
+                                                              )
+                                                            : activePage ?? 1;
                                                     setActivePageState(
                                                         parsedPage
                                                     );

--- a/frontend/components/Course/Summary/Summary.tsx
+++ b/frontend/components/Course/Summary/Summary.tsx
@@ -149,24 +149,14 @@ const Summary = (props: SummaryProps) => {
                                                 _,
                                                 { activePage }
                                             ) => {
-                                                let parsedPage: number;
-                                                if (
+                                                const parsedPage: number =
                                                     typeof activePage ===
                                                     "string"
-                                                ) {
-                                                    parsedPage = parseInt(
-                                                        activePage,
-                                                        10
-                                                    );
-                                                } else if (
-                                                    typeof activePage ===
-                                                    "number"
-                                                ) {
-                                                    parsedPage = activePage;
-                                                } else {
-                                                    // I'm not quite sure what would trigger this case though, so we fall back to 1
-                                                    parsedPage = 1;
-                                                }
+                                                        ? parseInt(
+                                                              activePage,
+                                                              10
+                                                          )
+                                                        : activePage ?? 1;
 
                                                 updateFilter({
                                                     page: parsedPage,


### PR DESCRIPTION
This PR paginates the roster page to display just 20 people at the same time. In the case where a filter is applied, it resets to the 1st page and also still displays 20 at the same time.
<img width="1123" alt="Screenshot 2023-11-05 at 1 07 39 PM" src="https://github.com/pennlabs/office-hours-queue/assets/67631406/063c16c3-7f0d-4b34-b691-07912f31d85d">
