### PR TITLE
[Improvements] Make page title more descriptive in course-related pages

### DIFF
--- a/frontend/pages/courses/[course]/analytics.tsx
+++ b/frontend/pages/courses/[course]/analytics.tsx
@@ -22,7 +22,7 @@ const AnalyticsPage = (props: AnalyticsPageProps) => {
     return (
         <>
             <Head>
-                <title>{`OHQ | ${course.department} ${course.courseCode}`}</title>
+                <title>{`OHQ | ${course.department} ${course.courseCode} | Analytics`}</title>
             </Head>
             <Grid columns="equal" divided style={{ width: "100%" }} stackable>
                 <CourseWrapper

--- a/frontend/pages/courses/[course]/index.tsx
+++ b/frontend/pages/courses/[course]/index.tsx
@@ -41,7 +41,7 @@ const QueuePage = (props: QueuePageProps) => {
             }
         >
             <Head>
-                <title>{`OHQ | ${course.department} ${course.courseCode}`}</title>
+                <title>{`OHQ | ${course.department} ${course.courseCode} | Queues`}</title>
             </Head>
             <Grid divided style={{ width: "100%" }} stackable>
                 <CourseWrapper

--- a/frontend/pages/courses/[course]/roster.tsx
+++ b/frontend/pages/courses/[course]/roster.tsx
@@ -26,7 +26,7 @@ const RosterPage = (props: RosterPageProps) => {
     return (
         <>
             <Head>
-                <title>{`OHQ | ${course.department} ${course.courseCode}`}</title>
+                <title>{`OHQ | ${course.department} ${course.courseCode} | Roster`}</title>
             </Head>
             <Grid columns="equal" divided style={{ width: "100%" }} stackable>
                 <CourseWrapper

--- a/frontend/pages/courses/[course]/settings.tsx
+++ b/frontend/pages/courses/[course]/settings.tsx
@@ -20,7 +20,7 @@ const SettingsPage = (props: SettingsPageProps) => {
     return (
         <>
             <Head>
-                <title>{`OHQ | ${course.department} ${course.courseCode}`}</title>
+                <title>{`OHQ | ${course.department} ${course.courseCode} | Settings`}</title>
             </Head>
             <Grid columns="equal" divided style={{ width: "100%" }} stackable>
                 <CourseWrapper

--- a/frontend/pages/courses/[course]/summary.tsx
+++ b/frontend/pages/courses/[course]/summary.tsx
@@ -20,7 +20,7 @@ const SummaryPage = (props: SummaryPageProps) => {
     return (
         <>
             <Head>
-                <title>{`OHQ | ${course.department} ${course.courseCode}`}</title>
+                <title>{`OHQ | ${course.department} ${course.courseCode} | Question Summary`}</title>
             </Head>
             <Grid columns="equal" divided style={{ width: "100%" }} stackable>
                 <CourseWrapper


### PR DESCRIPTION
This PR makes page titles for course-related pages more descriptive. Like adding `| Analytics` for Analytics pages or `| Roster` for Roster pages