### PR TITLE
:bug: Bug Fix for Queue Settings Pin Toggle

### DIFF
--- a/frontend/components/Course/InstructorQueuePage/QueueFormFields.tsx
+++ b/frontend/components/Course/InstructorQueuePage/QueueFormFields.tsx
@@ -172,11 +172,6 @@ const QueueFormFields = ({
         }
         setInput({ ...input });
     };
-
-    const handlePinInputChange = (e, { checked }) => {
-        input.pinEnabled = checked;
-        setInput({ ...input });
-    };
     /* PROPS UPDATE */
 
     return (
@@ -246,7 +241,12 @@ const QueueFormFields = ({
                     id="pin-toggle"
                     toggle
                     disabled={loading}
-                    onChange={handlePinInputChange}
+                    onClick={() =>
+                        setInput({
+                            ...input,
+                            pinEnabled: !input.pinEnabled,
+                        })
+                    }
                 />
             </Form.Field>
 
@@ -261,9 +261,9 @@ const QueueFormFields = ({
                     name="rateLimitEnabled"
                     id="rate-limit-toggle"
                     toggle
-                    defaultChecked={input.rateLimitEnabled}
+                    checked={input.rateLimitEnabled}
                     label="Enable queue rate-limiting"
-                    onChange={() =>
+                    onClick={() =>
                         setInput({
                             ...input,
                             rateLimitEnabled: !input.rateLimitEnabled,

--- a/frontend/components/Course/InstructorQueuePage/QueueFormFields.tsx
+++ b/frontend/components/Course/InstructorQueuePage/QueueFormFields.tsx
@@ -173,6 +173,13 @@ const QueueFormFields = ({
         setInput({ ...input });
     };
     /* PROPS UPDATE */
+    // Helper function to handle toggle changes
+    const handleToggleChange = (name: string) => {
+        setInput({
+            ...input,
+            [name]: !input[name],
+        });
+    };
 
     return (
         <>
@@ -241,12 +248,7 @@ const QueueFormFields = ({
                     id="pin-toggle"
                     toggle
                     disabled={loading}
-                    onClick={() =>
-                        setInput({
-                            ...input,
-                            pinEnabled: !input.pinEnabled,
-                        })
-                    }
+                    onClick={() => handleToggleChange("pinEnabled")}
                 />
             </Form.Field>
 
@@ -263,12 +265,7 @@ const QueueFormFields = ({
                     toggle
                     checked={input.rateLimitEnabled}
                     label="Enable queue rate-limiting"
-                    onClick={() =>
-                        setInput({
-                            ...input,
-                            rateLimitEnabled: !input.rateLimitEnabled,
-                        })
-                    }
+                    onClick={() => handleToggleChange("rateLimitEnabled")}
                 />
 
                 {input.rateLimitEnabled && (
@@ -382,11 +379,7 @@ const QueueFormFields = ({
                         toggle
                         label="Enable a countdown for questions"
                         onChange={() =>
-                            setInput({
-                                ...input,
-                                questionTimerEnabled:
-                                    !input.questionTimerEnabled,
-                            })
+                            handleToggleChange("questionTimerEnabled")
                         }
                     />
                 </Form.Field>


### PR DESCRIPTION
This is a minor bug fix to OHQ queue settings; there was an issue where you could not toggle off "Pin" and "Rate Limit" toggles once you turned them on. This was a small fix and works in testing.

Also, this patch was made using our new Waypoint tool, which is cool.