### PR TITLE
Added health routes to backend and frontend

### DIFF
--- a/backend/ohq/urls.py
+++ b/backend/ohq/urls.py
@@ -19,6 +19,7 @@ from ohq.views import (
     SemesterViewSet,
     TagViewSet,
     UserView,
+    HealthView,
 )
 
 
@@ -45,6 +46,7 @@ realtime_router.register(QuestionViewSet)
 realtime_router.register(AnnouncementViewSet)
 
 additional_urls = [
+    path("health/", HealthView.as_view(), name="health"),
     path("accounts/me/", UserView.as_view(), name="me"),
     path("accounts/me/resend/", ResendNotificationView.as_view(), name="resend"),
     path("courses/<slug:course_pk>/mass-invite/", MassInviteView.as_view(), name="mass-invite"),

--- a/backend/ohq/views.py
+++ b/backend/ohq/views.py
@@ -16,6 +16,7 @@ from django.db.models import (
     Subquery,
     When,
 )
+from django.views.generic import View
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.utils import timezone
 from django.utils.crypto import get_random_string
@@ -32,6 +33,7 @@ from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 from rest_live.mixins import RealtimeMixin
 from schedule.models import Event, EventRelationManager, Occurrence
+from http import HTTPStatus
 
 from ohq.filters import CourseStatisticFilter, QuestionSearchFilter, QueueStatisticFilter
 from ohq.invite import parse_and_send_invites
@@ -775,3 +777,22 @@ class OccurrenceViewSet(
 
     def get_queryset(self):
         return Occurrence.objects.filter(pk=self.kwargs["pk"])
+class HealthView(View):
+    def get(self, request):
+        """
+        Health check endpoint to confirm the backend is running.
+        ---
+        summary: Health Check
+        responses:
+            "200":
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                message:
+                                    type: string
+                                    enum: ["OK"]
+        ---
+        """
+        return JsonResponse({"message": "OK"}, status=HTTPStatus.OK) 

--- a/backend/tests/ohq/test_health.py
+++ b/backend/tests/ohq/test_health.py
@@ -1,0 +1,9 @@
+from django.test import TestCase
+from django.urls import reverse
+
+class HealthTestCase(TestCase):
+    def test_health(self):
+        url = reverse("health")
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, {"message": "OK"})

--- a/frontend/pages/health.tsx
+++ b/frontend/pages/health.tsx
@@ -1,0 +1,24 @@
+import { GetServerSideProps } from 'next';
+
+const HealthPage = () => {
+    return <div>OK</div>;
+};
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+    const userAgent = req.headers['user-agent'] || '';
+
+    if (userAgent !== 'service-status') {
+        return {
+            redirect: {
+                destination: '/',
+                permanent: false,
+            },
+        };
+    }
+
+    return {
+        props: {},
+    };
+};
+
+export default HealthPage;

--- a/frontend/pages/health.tsx
+++ b/frontend/pages/health.tsx
@@ -1,16 +1,16 @@
-import { GetServerSideProps } from 'next';
+import { GetServerSideProps } from "next";
 
 const HealthPage = () => {
     return <div>OK</div>;
 };
 
 export const getServerSideProps: GetServerSideProps = async ({ req }) => {
-    const userAgent = req.headers['user-agent'] || '';
+    const userAgent = req.headers["user-agent"] || "";
 
-    if (userAgent !== 'service-status') {
+    if (userAgent !== "service-status") {
         return {
             redirect: {
-                destination: '/',
+                destination: "/",
                 permanent: false,
             },
         };


### PR DESCRIPTION
Created health page (health.tsx) in frontend
* If user-agent: service-status is a header, it will return OK
* Otherwise, it redirects to the home page
* `/health`

Created health route in backend
* `/api/health`